### PR TITLE
Fixed crash that stops strider if an error happens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ requirements
 
 contributors
 ============
-  * nodefourtytwo ([nodefourtytwo/strider-gitlab](https://github.com/nodefourtytwo/strider-gitlab)) for providing the basic plugin which i've continued to develop
+  * Martin Ericson (http://www.devbox.com)
+  * [nodefourtytwo/strider-gitlab](https://github.com/nodefourtytwo/strider-gitlab)
   * [jonlil](https://github.com/jonlil)
 
 license

--- a/lib/api.js
+++ b/lib/api.js
@@ -23,7 +23,7 @@ function get(config, uri, callback){
         url: url,
         json: true
     }, function(err, res){
-        if (res.statusCode != 200) {
+        if (res && res.statusCode != 200) {
             return callback(new Error("API seems to be broken: Status:" + res.statusCode));
         }
         callback(err, res ? res.body : null);

--- a/lib/api.js
+++ b/lib/api.js
@@ -26,7 +26,7 @@ function get(config, uri, callback){
         if (res.statusCode != 200) {
             return callback(new Error("API seems to be broken: Status:" + res.statusCode));
         }
-        callback(err, res.body);
+        callback(err, res ? res.body : null);
     });
 }
 


### PR DESCRIPTION
If an error occurs "res" will be null, thus we get a null pointer exception. Fixed that by wrapping it in a nullish test.