### PR TITLE
Added verbose error message for a wrong status

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -23,6 +23,9 @@ function get(config, uri, callback){
         url: url,
         json: true
     }, function(err, res){
+        if (res.statusCode != 200) {
+            return callback(new Error("API seems to be broken: Status:" + res.statusCode));
+        }
         callback(err, res.body);
     });
 }


### PR DESCRIPTION
If the server returns a 404 error message for the api url then the code will break when a subsequent method tries to analyse that response body. This way the error is clearer.
