### PR TITLE
clarify error message; bump version for minor release

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -30,7 +30,7 @@ function get(config, uri, callback) {
         }
         
         if (res.statusCode !== 200) {
-            return callback(new Error("API seems to be broken: Status:" + res.statusCode));
+            return callback(new Error("Cannot access GitLab API. Please verify your private token. (Status:" + res.statusCode + ")"));
         }
         
         callback(undefined, res.body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strider-gitlab",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A gitlab provider for strider",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request contains minor error message changes to clarify any error output regarding the strider-gitlab plugin.

Additionally, it already has the fix for https://github.com/Strider-CD/strider/issues/767. The problem: installing dependencies for Strider with `npm install` right after cloning the repository installs and old version of the **strider-gitlab** plugin. The ecosystem-index already contains version `1.0.5` including the fix for above referenced issue. However, you need to reinstall the plugin via admin panel to get the fixed code.