### PR TITLE
Use the reference branch to get files

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -39,7 +39,7 @@ module.exports = {
 
     getFile: function (filename, ref, account, config, project, done){
         var repo_id = project.provider.repo_id,
-            branch = project.branches[0].name;
+            branch = ref.branch;
 
         var uri = util.format("projects/%d/repository/blobs/%s?filepath=%s", repo_id, branch, filename);
 


### PR DESCRIPTION
Previously, the first available branch was used, which is counter-intuitive to the user. Files should be retrieved from the branch referenced in the current build.

Fixes #10