### PR TITLE
Don't pre-parse JSON responses

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -22,8 +22,7 @@ function get(config, uri, callback) {
         url = config.api_url + '/' + uri + glue + qs.stringify(qpm);
 
     request.get({
-        url: url,
-        json: true
+        url: url
     }, function(err, res) {
         if (err) {
             return callback(err);


### PR DESCRIPTION
Strider does not expect pre-parsed responses, so don't do it.

Fixes #12