### PR TITLE
Don't handle errors in the API layer

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -27,11 +27,7 @@ function get(config, uri, callback) {
         if (err) {
             return callback(err);
         }
-        
-        if (res.statusCode !== 200) {
-            return callback(new Error("Cannot access GitLab API. Please verify your private token. (Status:" + res.statusCode + ")"));
-        }
-        
+                
         callback(undefined, res.body);
     });
 }


### PR DESCRIPTION
The previous version would cause fatal errors, even when only a 404 was raised (like when strider.json doesn't exist).
Other providers (like github) will only raise errors on connection errors.
This provider should behave the same way.