### PR TITLE
Make error signature on-par with strider-github

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,7 +1,8 @@
 var request = require('request'),
     qs = require('querystring'),
     _ = require('lodash'),
-    async = require('async');
+    async = require('async'),
+    superagent = require('superagent');
 
 module.exports = {
     get: get,
@@ -12,23 +13,39 @@ module.exports = {
     removeDeployKey: removeDeployKey
 };
 
+/**
+ * Retrieve a file from a GitLab repository, using the GitLab API.
+ * @param {Object} config The configuration of the GitLab provider plugin.
+ * @param {String} uri The URI of the file to retrieve.
+ * @param {Function} done A function to call, once a result is available.
+ */
+function get(config, uri, done) {
+    // If the configuration has no GitLab API URL, bail.
+    if (!config.api_url) {
+        return done(new Error('API URL missing from GitLab provider configuration!'));
+    }
+    // Append a slash to the URL if there isn't one.
+    var apiBase = config.api_url;
+    if (!/\/$/.test(apiBase)) {
+        apiBase += '/';
+    }
+    // Construct the complete request URL
+    var url = apiBase + uri;
+    var req = superagent.get(url).set('User-Agent', 'StriderCD (http://stridercd.com)');
+    // Add our additional request parameters to the query part of the URL.
+    req.query({
+        private_token: config.api_key,
+        per_page: 100
+    });
 
-function get(config, uri, callback) {
-    var qpm = {
-            private_token: config.api_key,
-            per_page: 100
-        },
-        glue = (~uri.indexOf('?')) ? "&" : "?",
-        url = config.api_url + '/' + uri + glue + qs.stringify(qpm);
-
-    request.get({
-        url: url
-    }, function(err, res) {
-        if (err) {
-            return callback(err);
+    req.end(function (res) {
+        if (res.error) {
+            return done(res.error, null);
         }
-                
-        callback(undefined, res.body);
+        if (!res.body) {
+            return done();
+        }
+        done(null, res.body);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "lodash": "~2.2.0",
     "request": "~2.27.0",
     "step": "0.0.5",
-    "strider-git": "^0.2.3"
+    "strider-git": "^0.2.3",
+    "superagent": "~0.15.4"
   },
   "bugs": {
     "url": "https://github.com/meric426/strider-gitlab/issues"


### PR DESCRIPTION
API interaction is now partially handled by superagent. This enables the same error signature that is expected in other parts of the application.

More specifically, what superagent treats as a soft error (non-200 response) is now communicated as such. This allows, for example, the `strider.json` retrieval to perform as expected.

Additionally, behavior and code are now more similar to that of `strider-github`.