### PR TITLE
Add [skip ci] feature from github provider

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -32,6 +32,12 @@ function makeJob(project, config) {
 
 function startFromCommit(project, payload, send) {
   var config = pushJob(payload);
+  var lastCommit = payload.commits[payload.commits.length - 1];
+
+  if (lastCommit.message.indexOf('[skip ci]') > -1) {
+    return { skipCi: true };
+  }
+
   var branch = project.branch(config.branch);
   var job;
 
@@ -92,7 +98,13 @@ function receiveWebhook(emitter, req, res) {
 
   res.sendStatus(204);
 
-  startFromCommit(req.project, payload, sendJob);
+  var result = startFromCommit(req.project, payload, sendJob);
+
+  if (result && result.skipCi) {
+    console.log('Skipping commit due to [skip ci] tag');
+  } else if (!result) {
+    console.log('webhook received, but no branches matched or branch is not active');
+  }
 
   function sendJob(job) {
     emitter.emit('job.prepare', job)


### PR DESCRIPTION
The github provider allows skipping CI by adding "[skip ci]" to your commit message. This change brings the same feature to the gitlab provider.