### PR TITLE
Use debug instead of console

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var debug = require('debug')('strider-gitlab:webhooks');
 var gravatar = require('gravatar');
 
 module.exports = {
@@ -101,9 +102,9 @@ function receiveWebhook(emitter, req, res) {
   var result = startFromCommit(req.project, payload, sendJob);
 
   if (result && result.skipCi) {
-    console.log('Skipping commit due to [skip ci] tag');
+    debug('Skipping commit due to [skip ci] tag');
   } else if (!result) {
-    console.log('webhook received, but no branches matched or branch is not active');
+    debug('webhook received, but no branches matched or branch is not active');
   }
 
   function sendJob(job) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
+    "debug": "~0.7.3",
     "gravatar": "^1.0.6",
     "lodash": "~2.2.0",
     "step": "0.0.5",


### PR DESCRIPTION
Uses the same version of debug and the same approach (`plugin:file`) as strider-github.