### PR TITLE
Crash on receiving bad data when listing projects

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 var async = require('async');
 var superagent = require('superagent');
+var debug = require('debug')('strider-gitlab:api');
 
 module.exports = {
   get: get,
@@ -38,6 +39,8 @@ function get(config, uri, done) {
     .set('User-Agent', 'StriderCD (http://stridercd.com)')
     .end(function (error, res) {
       res = res || {};
+      debug('Response body type: ' + typeof res.body);
+      debug('Response body received: ' + JSON.stringify(res.body));
       if (res.error) {
         return done(res.error, null, res);
       }

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -3,7 +3,7 @@ var api = require('./api');
 var async = require('async');
 var util = require('util');
 var webhooks = require('./webhooks');
-
+var debug = require('debug')('strider-gitlab:webapp');
 var hostname = process.env.strider_server_name || 'http://localhost:3000';
 
 module.exports = {
@@ -30,7 +30,9 @@ module.exports = {
     api.get(config, 'projects', function (err, repos) {
       if (err) return done(err);
 
-      repos = JSON.parse(repos);
+      if(!repos) {
+          return done(new Error("Could not get a list of projects from the GitLab repository. Please check the configuration in Account->GitLab."));
+      }
 
       // Parse and filter only git repos
       done(null, repos.map(api.parseRepo).filter(function (repo) {
@@ -55,9 +57,9 @@ module.exports = {
 
     var uri = util.format('projects/%d/repository/branches', repo_id);
 
+    debug("Getting URI " + uri);
     api.get(account, uri, function (err, branches) {
-
-      branches = JSON.parse(branches);
+    debug("We get the following as branches: " + JSON.stringify(branches));
 
       done(err, _.map(branches || [], function (branch) {
         return branch.name


### PR DESCRIPTION
When there was a problem in the gitlab configuration and
an unreachable/incorrect hostname was specified, instead
of JSON, we were getting undefined from the get
method in api.js, and we were crashing.

Added an error message for this case so that we do not
crash.

Ideally we should be checking for a valid reachable gitlab
host when saving the configuration.

Crash trace below:

SyntaxError: Unexpected token u
	at Object.parse (native)
	at /home/dev/sandbox/strider/node_modules/strider-gitlab/lib/webapp.js:34:20
	at /home/dev/sandbox/strider/node_modules/strider-gitlab/lib/api.js:45:16
	at Request.callback (/home/dev/sandbox/strider/node_modules/strider-gitlab/node_modules/superagent/lib/node/index.js:628:30)
	at ClientRequest.<anonymous> (/home/dev/sandbox/strider/node_modules/strider-gitlab/node_modules/superagent/lib/node/index.js:596:10)
	at ClientRequest.emit (events.js:107:17)
	at Socket.socketErrorListener (_http_client.js:271:9)
	at Socket.emit (events.js:107:17)
	at net.js:459:14
	at process._tickCallback (node.js:355:11)
9284 died 1 null