### PR TITLE
Running Test from Configure project page crashes

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -48,7 +48,12 @@ module.exports = {
     var uri = util.format('projects/%d/repository/blobs/%s?filepath=%s', repo_id, branch, filename);
 
     api.get(account.config, uri, function (err, data, res) {
-      done(err, res.text);
+      if(err) {
+        return done(err, null);
+      }
+      else {
+        done(err, res.text);
+      }
     });
   },
 

--- a/test/mocks/gitlab_webapp_getfile.js
+++ b/test/mocks/gitlab_webapp_getfile.js
@@ -33,4 +33,21 @@ module.exports = function () {
       'x-runtime': '0.013665',
       'content-encoding': 'gzip'
     });
+
+  //--------------------------------------------------------------------------------------
+  //Simulate a scenario where the project does not contain a strider.json
+  //For this purpose we have added another project named priproject2 with id 8
+  nock('http://localhost:80')
+    .get('/api/v3/projects/8/repository/blobs/master')
+    .query({"private_token":"zRtVsmeznn7ySatTrnrp","per_page":"100","filepath":"strider.json"})
+    .reply(404, ["1f8b0800000000000003ab56ca4d2d2e4e4c4f55b2523231305170cbcc4955f0cb2f5170cb2fcd4b51aa0500db72e71020000000"], { server: 'nginx',
+    date: 'Mon, 24 Aug 2015 06:28:17 GMT',
+    'content-type': 'application/json',
+    'transfer-encoding': 'chunked',
+    connection: 'close',
+    status: '404 Not Found',
+    'cache-control': 'no-cache',
+    'x-request-id': '9e221d4c-9109-4291-929b-2e7cb1e4f057',
+    'x-runtime': '0.022119',
+    'content-encoding': 'gzip' });
 };

--- a/test/test_webapp.js
+++ b/test/test_webapp.js
@@ -49,6 +49,21 @@ var providerConfig = {
   auth: {type: 'ssh'}
 };
 
+var providerConfigForProjectWithMissingStriderJson = 
+{ whitelist: [],
+  pull_requests: 'none',
+  repo: 'http://nodev/stridertester/priproject2',
+  owner:
+   { avatar_url: 'http://www.gravatar.com/avatar/3f671ed86ed3d21ed3640c7a016b0997?s=40&d=identicon',
+     state: 'active',
+     id: 3,
+     username: 'stridertester',
+     name: 'Strider Tester' },
+  url: 'git@nodev:stridertester/priproject2.git',
+  scm: 'git',
+  auth: { type: 'ssh' } 
+};
+
 var repoProject = {
   name: 'stridertester/privproject1',
   display_name: 'stridertester/privproject1',
@@ -127,32 +142,48 @@ describe('gitlab webapp', function () {
       nock.cleanAll();
     });
 
+    var filename = "strider.json";
+
+    var ref = {
+      branch: 'master',
+    };
+
+    //getFile only uses account.config
+    var account = {
+      config: {
+        api_key: 'zRtVsmeznn7ySatTrnrp',
+        api_url: 'http://localhost:80/api/v3'
+      }
+    };
+
+
+    //getFile only uses project.provider.repo_id
+    var project = {
+      provider: {
+        repo_id: '5'
+      }
+    };
+
+    //project with strider.json missing
+    var projectWithMissingStriderJson ={
+      provider: {
+        repo_id: '8'
+      }
+    };
+
 
     it('should get a json file correctly', function (done) {
-      var filename = "strider.json";
-
-      var ref = {
-        branch: 'master',
-      };
-
-      //getFile only uses account.config
-      var account = {
-        config: {
-          api_key: 'zRtVsmeznn7ySatTrnrp',
-          api_url: 'http://localhost:80/api/v3'
-        }
-      };
-
-
-      //getFile only uses project.provider.repo_id
-      var project = {
-        provider: {
-          repo_id: '5',
-        }
-      }
-
       webapp.getFile(filename, ref, account, providerConfig, project, function (err, text) {
         expect(text).to.be.a('string');
+        done();
+      });
+    });
+
+    //created a project priproject2 of type node.js, but not having a strider.json for this test
+    it('should not crash, but return an error if the file could not be found', function(done) {
+      webapp.getFile(filename, ref, account, providerConfigForProjectWithMissingStriderJson, projectWithMissingStriderJson, function (err, text) {
+        expect(err).to.be.ok();
+        expect(text).to.not.be.ok();
         done();
       });
     });


### PR DESCRIPTION
If the project does not contain a strider.json.
In webapp.getFile, we are ignoring the error
received in our callback and trying to read
res.text, without trying to check if res exists.

```
	/noderoot/strider-gitlab/lib/webapp.js:51
		  done(err, res.text);
					   ^
	TypeError: Cannot read property 'text' of null
		at /noderoot/strider-gitlab/lib/webapp.js:51:20
		at /noderoot/strider-gitlab/lib/api.js:45:16
		at Request.callback (/noderoot/strider-gitlab/node_modules/superagent/lib/node/index.js:797:3)
		at Stream.<anonymous> (/noderoot/strider-gitlab/node_modules/superagent/lib/node/index.js:991:12)
		at Stream.emit (events.js:129:20)
		at Unzip.<anonymous> (/noderoot/strider-gitlab/node_modules/superagent/lib/node/utils.js:108:12)
		at Unzip.emit (events.js:129:20)
		at _stream_readable.js:908:16
		at process._tickDomainCallback (node.js:381:11)
```

Wrote a failing test for this scenario.