### PR TITLE
was printing branch inactive/no branch matched even when job created …

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -109,5 +109,6 @@ function receiveWebhook(emitter, req, res) {
 
   function sendJob(job) {
     emitter.emit('job.prepare', job);
+    return true;
   }
 }


### PR DESCRIPTION
…successfully

We were expecting a true result from sendJob to
determine if the job was created successfully.
However sendJob was only emitting a job.prepare
message and not returning anything.