### PR TITLE
Fix for webapp.getFile()

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -47,7 +47,7 @@ module.exports = {
     var encodedFileName = encodeURIComponent(filename);
     var uri = util.format('projects/%d/repository/blobs/%s?filepath=%s', repoId, branch, encodedFileName);
 
-    api.get(account.config, uri, function (err, data, res) {
+    api.get(account, uri, function (err, data, res) {
       if(err) {
         return done(err, null);
       } else {

--- a/test/test_webapp.js
+++ b/test/test_webapp.js
@@ -49,7 +49,7 @@ var providerConfig = {
   auth: {type: 'ssh'}
 };
 
-var providerConfigForProjectWithMissingStriderJson = 
+var providerConfigForProjectWithMissingStriderJson =
 { whitelist: [],
   pull_requests: 'none',
   repo: 'http://nodev/stridertester/priproject2',
@@ -61,7 +61,7 @@ var providerConfigForProjectWithMissingStriderJson =
      name: 'Strider Tester' },
   url: 'git@nodev:stridertester/priproject2.git',
   scm: 'git',
-  auth: { type: 'ssh' } 
+  auth: { type: 'ssh' }
 };
 
 var repoProject = {
@@ -150,10 +150,8 @@ describe('gitlab webapp', function () {
 
     //getFile only uses account.config
     var account = {
-      config: {
         api_key: 'zRtVsmeznn7ySatTrnrp',
         api_url: 'http://localhost:80/api/v3'
-      }
     };
 
 


### PR DESCRIPTION
Using the latest strider build 1.7.7 with this plugin, I received the following error:

> /home/deriven/github/Strider-CD/strider/node_modules/mongoose/lib/utils.js:413
>         throw err;
>         ^
> 
> TypeError: Cannot read property 'api_url' of undefined
>     at Object.get (/home/deriven/github/Strider-CD/strider/node_modules/strider-gitlab/lib/api.js:25:14)
>     at Object.module.exports.getFile (/home/deriven/github/Strider-CD/strider/node_modules/strider-gitlab/lib/webapp.js:51:9)
>     at striderJson (/home/deriven/github/Strider-CD/strider/lib/backchannel.js:42:12)
>     at Promise.<anonymous> (/home/deriven/github/Strider-CD/strider/lib/backchannel.js:75:7)
>     at Promise.<anonymous> (/home/deriven/github/Strider-CD/strider/node_modules/mpromise/lib/promise.js:177:8)
>     at emitOne (events.js:90:13)
>     at Promise.emit (events.js:182:7)
>     at Promise.emit (/home/deriven/github/Strider-CD/strider/node_modules/mpromise/lib/promise.js:84:38)
>     at Promise.fulfill (/home/deriven/github/Strider-CD/strider/node_modules/mpromise/lib/promise.js:97:20)
>     at Promise.<anonymous> (/home/deriven/github/Strider-CD/strider/node_modules/mongoose/lib/model.js:1544:35)
>     at Promise.<anonymous> (/home/deriven/github/Strider-CD/strider/node_modules/mpromise/lib/promise.js:177:8)
>     at emitTwo (events.js:100:13)
>     at Promise.emit (events.js:185:7)
>     at Promise.emit (/home/deriven/github/Strider-CD/strider/node_modules/mpromise/lib/promise.js:84:38)
>     at Promise.fulfill (/home/deriven/github/Strider-CD/strider/node_modules/mpromise/lib/promise.js:97:20)
>     at handleSave (/home/deriven/github/Strider-CD/strider/node_modules/mongoose/lib/model.js:133:13)
>     at /home/deriven/github/Strider-CD/strider/node_modules/mongoose/lib/utils.js:408:16
>     at /home/deriven/github/Strider-CD/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/collection/core.js:128:9
>     at /home/deriven/github/Strider-CD/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1197:7
>     at /home/deriven/github/Strider-CD/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1905:9
>     at Server.Base._callHandler (/home/deriven/github/Strider-CD/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/base.js:453:41)
>     at /home/deriven/github/Strider-CD/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/server.js:488:18
> 

Added a few console.log outputs to find out that `account.config` didn't exist.  This pull requests fixes this error by passing `account`.  I modified the test as well.