### PR TITLE
Stop repos from being listed twice

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -59,7 +59,7 @@ function get(config, uri, done) {
 
       if (res.headers.link) {
         var numberOfPages = parseLinkHeader(res.headers.link).last.page;
-        var i = 0;
+        var i = 1;
 
         async.whilst(
           function() {

--- a/test/test_webapp.js
+++ b/test/test_webapp.js
@@ -293,7 +293,7 @@ describe('gitlab webapp', function () {
       webapp.listRepos(config, function (err, repos) {
         expect(err).to.not.be.ok();
         expect(repos).to.be.an('array');
-        expect(repos.length).to.eql(6);
+        expect(repos.length).to.eql(3);
         done();
       });
     });


### PR DESCRIPTION
Currently, repos added from GitLab show up twice
![image](https://cloud.githubusercontent.com/assets/7266957/15134183/c8e3819c-1637-11e6-9487-abcb1c0069a9.png)

This happens because the list of pages is 1-indexed rather than 0-indexed like the plugin seems to be expecting. We get the results from the first page on line 58 of `api.js`:

```javascript
var results = res.body;
```

`api.js` then does a `while i < numberOfPages` to loop through any additional pages. Currently, `i` is set to `0` to start with (line 62) and then incremented after the check against `numberOfPages` (increment on line 69). This causes it to re-fetch the list of repos from page 1, even if that was the only page of repos (since `i` is 0 when the comparison to `numberOfPages` is done). The results from page 1 are then added to the results we already got from page 1 on line 81:

```javascript
results = results.concat(res.body);
```

This PR just changes line 62 to set `i` equal to `1` so that we only go through the `while` loop for pages 2+. The result is a list of repos without duplicates:
![image](https://cloud.githubusercontent.com/assets/7266957/15134266/859665ac-1638-11e6-844d-44c3594de05a.png)